### PR TITLE
Rename mdast to remark

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ var fs = require('fs'),
   hljs = require('highlight.js'),
   Handlebars = require('handlebars'),
   getDoc = require('globals-docs').getDoc,
-  mdast = require('mdast'),
-  html = require('mdast-html'),
+  remark = require('remark'),
+  html = require('remark-html'),
   inlineLex = require('jsdoc-inline-lex');
 
 /**
@@ -151,12 +151,12 @@ module.exports = function (comments, options, callback) {
    * // generates <h2>foo</h2>
    */
   Handlebars.registerHelper('md', function formatMarkdown(string) {
-    return new Handlebars.SafeString(mdast().use(html, htmlOptions)
+    return new Handlebars.SafeString(remark().use(html, htmlOptions)
         .process(formatInlineTags(paths, string)));
   });
 
   Handlebars.registerHelper('format_type', function (type) {
-    return mdast().use(html, htmlOptions)
+    return remark().use(html, htmlOptions)
       .stringify({
         type: 'root',
         children: utils.formatType(type, paths)

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "handlebars": "^3.0.3",
     "highlight.js": "^9.0.0",
     "jsdoc-inline-lex": "^1.0.1",
-    "mdast": "^2.0.0",
-    "mdast-html": "^1.2.1",
+    "remark": "^3.0.0",
+    "remark-html": "^2.0.0",
     "vinyl": "^1.0.0",
     "vinyl-fs": "^2.0.0"
   }


### PR DESCRIPTION
P.S. `eslint` isn’t in the local dependencies so I couldn’t get the tests to pass initially locally.
